### PR TITLE
Handle mouse buttons accordind to the spec

### DIFF
--- a/src/StatusNotifier/Tray.hs
+++ b/src/StatusNotifier/Tray.hs
@@ -315,11 +315,16 @@ buildTray TrayParams { trayHost = Host
               popupItemForMenu menu =
                 Gtk.menuPopupAtWidget menu image
                    GravitySouthWest GravityNorthWest Nothing
-              popupItemMenu =
-                maybe activateItem popupItemForMenu maybeMenu >> return False
-              activateItem = void $ IC.activate client serviceName servicePath 0 0
+              activate f = void $ f client serviceName servicePath 0 0
 
-          _ <- Gtk.onWidgetButtonPressEvent button $ const popupItemMenu
+          _ <- Gtk.onWidgetButtonPressEvent button $ \event -> do
+            number <- Gdk.getEventButtonButton event
+            case number of
+              1 -> activate IC.activate
+              2 -> activate IC.secondaryActivate
+              3 -> maybe (return ()) popupItemForMenu maybeMenu
+              _ -> return ()
+            return False
           _ <- Gtk.onWidgetScrollEvent button $ \event -> do
             direction <- getEventScrollDirection event
             let direction' = case direction of


### PR DESCRIPTION
Resolves #14

According to the [spec](https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/StatusNotifierItem/) left mouse button should send activate, middle - secondary activate, right - show menu.

There is one drawback though - there are items that should always show menu. This is what we have now but won't have anymore after this PR. It's defined via `ItemIsMenu` property. But it's currently not supported in `status-notifier-item`. @IvanMalison is [xml](https://github.com/taffybar/status-notifier-item/blob/master/xml/StatusNotifierItem.xml) there manually written or it's provided somewhere? Could you update it and make a release?

Also I noticed that there is `ContextMenu` method. @IvanMalison why it's not used and instead menu is created manually?