### PR TITLE
Fix scale.

### DIFF
--- a/src/StatusNotifier/Tray.hs
+++ b/src/StatusNotifier/Tray.hs
@@ -55,7 +55,7 @@ getScaledWidthHeight shouldTargetWidth targetSize width height =
       getRatio toScale =
         fromIntegral targetSize / fromIntegral toScale
       getOther :: Int32 -> Int32 -> Int32
-      getOther toScale other = floor $ getRatio toScale * fromIntegral other
+      getOther toScale other = max 1 $ floor $ getRatio toScale * fromIntegral other
   in
     if shouldTargetWidth
     then (targetSize, getOther width height)


### PR DESCRIPTION
Gtk requires size to be >0.

I get the following error periodically:

```
Jul 28 00:34:14 dell taffybar-linux-[265044]: gdk_pixbuf_scale_simple: assertion 'dest_width > 0' failed
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - targetW: 0, targetH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - Scaling pb to 1, actualW: 59, actualH: 96, scaledW: 0, scaledH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - targetW: 1, targetH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - Scaling pb to 1, actualW: 16, actualH: 16, scaledW: 1, scaledH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - targetW: 1, targetH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - Scaling pb to 1, actualW: 1, actualH: 1, scaledW: 1, scaledH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - targetW: 1, targetH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - Scaling pb to 1, actualW: 1, actualH: 1, scaledW: 1, scaledH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - targetW: 1, targetH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - Scaling pb to 1, actualW: 1, actualH: 1, scaledW: 1, scaledH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - targetW: 1, targetH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - Scaling pb to 1, actualW: 1, actualH: 1, scaledW: 1, scaledH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - targetW: 1, targetH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - Scaling pb to 1, actualW: 1, actualH: 1, scaledW: 1, scaledH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - targetW: 1, targetH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - Scaling pb to 1, actualW: 1, actualH: 1, scaledW: 1, scaledH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - targetW: 1, targetH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - Scaling pb to 1, actualW: 1, actualH: 1, scaledW: 1, scaledH: 1
Jul 28 00:34:14 dell taffybar[265044]: [WARNING] System.Taffybar.Widget.Generic.AutoSizeImage - Allocating image: size 1, width 1,  height 1, aw: 1, ah: 1, pbw: 59 pbh: 96
Jul 28 00:34:14 dell taffybar[265044]: [WARNING] StatusNotifier.Tray - Unable to scale pixbuf
Jul 28 00:34:14 dell taffybar-linux-[265044]: gdk_pixbuf_scale_simple: assertion 'dest_width > 0' failed
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - targetW: 0, targetH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - Scaling pb to 1, actualW: 59, actualH: 96, scaledW: 0, scaledH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - targetW: 1, targetH: 1
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - Scaling pb to 1, actualW: 1, actualH: 1, scaledW: 1, scaledH: 1
Jul 28 00:34:14 dell taffybar[265044]: [WARNING] System.Taffybar.Widget.Generic.AutoSizeImage - Allocating image: size 1, width 1,  height 1, aw: 1, ah: 1, pbw: 59 pbh: 96
Jul 28 00:34:14 dell taffybar[265044]: [WARNING] StatusNotifier.Tray - Unable to scale pixbuf
Jul 28 00:34:14 dell taffybar-linux-[265044]: gdk_pixbuf_scale_simple: assertion 'dest_width > 0' failed
Jul 28 00:34:14 dell taffybar[265044]: [DEBUG] StatusNotifier.Tray - targetW: 0, targetH: 1
```