### PR TITLE
Bump version to 0.1.9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,15 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Nix Flake - Linux
     steps:
-      - name: Install Nix
-        uses: cachix/install-nix-action@v13
-        with:
-          install_url: https://nixos-nix-install-tests.cachix.org/serve/i6laym9jw3wg9mw6ncyrk6gjx4l34vvx/install
-          install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Clone project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         run: nix build
+      - run: nix flake check

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .stack-work/
 /dist-newstyle
 /result*
-gtk-sni-tray.cabal
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .stack-work/
+/dist-newstyle
+/result*
 gtk-sni-tray.cabal
 *~

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
 # Changelog for gtk-sni-tray
 
-## Unreleased changes
+## 0.1.9.0
+
+- Use the `gi-gtk3` and `gi-gdk3` build dependencies, which have been
+  renamed from `gi-gtk` and `gi-gdk`.
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,136 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "git-ignore-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gtk-strut": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "git-ignore-nix": [
+          "git-ignore-nix"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1760271730,
+        "narHash": "sha256-AiVtcbO+JR/XwHALm8z6kiN14f5lJ/iwkVI7khYy+oA=",
+        "owner": "taffybar",
+        "repo": "gtk-strut",
+        "rev": "62e8e83f861d562ff360f356b1d4b64f6576d329",
+        "type": "github"
+      },
+      "original": {
+        "owner": "taffybar",
+        "repo": "gtk-strut",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1760038930,
+        "narHash": "sha256-Oncbh0UmHjSlxO7ErQDM3KM0A5/Znfofj2BSzlHLeVw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0b4defa2584313f3b781240b29d61f6f9f7e0df3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "git-ignore-nix": "git-ignore-nix",
+        "gtk-strut": "gtk-strut",
+        "nixpkgs": "nixpkgs",
+        "status-notifier-item": "status-notifier-item"
+      }
+    },
+    "status-notifier-item": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "git-ignore-nix": [
+          "git-ignore-nix"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1641783528,
+        "narHash": "sha256-wJymJfYPFj4/r1e4kT/wt9FEsyCXo5JkkcOoozpuhag=",
+        "owner": "taffybar",
+        "repo": "status-notifier-item",
+        "rev": "f4f9c66ab57fc42eeed0de8cfac9f5f9d30d9dc7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "taffybar",
+        "repo": "status-notifier-item",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,31 +1,57 @@
 {
   description = "gtk-sni-tray";
   inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    git-ignore-nix.url = github:hercules-ci/gitignore.nix/master;
-    status-notifier-item.url = "github:taffybar/status-notifier-item/master";
+    git-ignore-nix = {
+      url = "github:hercules-ci/gitignore.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    status-notifier-item = {
+      url = "github:taffybar/status-notifier-item";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.git-ignore-nix.follows = "git-ignore-nix";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+    gtk-strut = {
+      url = "github:taffybar/gtk-strut";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.git-ignore-nix.follows = "git-ignore-nix";
+      inputs.flake-utils.follows = "flake-utils";
+    };
   };
-  outputs = { self, flake-utils, nixpkgs, git-ignore-nix, status-notifier-item }:
-  let
-    overlay = final: prev: {
-      haskellPackages = prev.haskellPackages.override (old: {
-        overrides = prev.lib.composeExtensions (old.overrides or (_: _: {}))
-        (hself: hsuper: {
-          gtk-sni-tray =
-            hself.callCabal2nix "gtk-sni-tray"
-            (git-ignore-nix.lib.gitignoreSource ./.)
-            { inherit (final) gtk3;  };
-        });
-      });
+  outputs = { self, flake-utils, nixpkgs, git-ignore-nix, status-notifier-item, gtk-strut }:
+  flake-utils.lib.eachDefaultSystem (system: let
+    inherit (nixpkgs) lib;
+    pkgs = import nixpkgs {
+      inherit system;
+      overlays = lib.attrValues self.overlays;
+      config.allowBroken = true;
     };
-    overlays = [ overlay status-notifier-item.overlay ];
-  in flake-utils.lib.eachDefaultSystem (system:
-  let pkgs = import nixpkgs { inherit system overlays; config.allowBroken = true; };
   in
-  rec {
-    devShell = pkgs.haskellPackages.shellFor {
+  {
+    devShells.default = pkgs.haskellPackages.shellFor {
       packages = p: [ p.gtk-sni-tray ];
+      nativeBuildInputs = with pkgs.haskellPackages; [
+        cabal-install haskell-language-server
+      ];
     };
-    defaultPackage = pkgs.haskellPackages.gtk-sni-tray;
-  }) // { inherit overlay overlays; } ;
+    packages.default = pkgs.haskellPackages.gtk-sni-tray;
+  }) // {
+    overlays = {
+      default = final: prev: {
+        haskellPackages = prev.haskellPackages.override (old: {
+          overrides = final.lib.composeExtensions (old.overrides or (_: _: {}))
+          (hself: hsuper: {
+            gtk-sni-tray =
+              hself.callCabal2nix "gtk-sni-tray"
+              (git-ignore-nix.lib.gitignoreSource ./.)
+              { inherit (final) gtk3;  };
+          });
+        });
+      };
+      status-notifier-item = status-notifier-item.overlay or status-notifier-item.overlays.default;
+      gtk-strut = gtk-strut.overlay or gtk-strut.overlays.default;
+    };
+  };
 }

--- a/gtk-sni-tray.cabal
+++ b/gtk-sni-tray.cabal
@@ -1,0 +1,85 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.38.2.
+--
+-- see: https://github.com/sol/hpack
+
+name:           gtk-sni-tray
+version:        0.1.9.0
+synopsis:       A standalone StatusNotifierItem/AppIndicator tray
+description:    Please see the README on Github at <https://github.com/IvanMalison/gtk-sni-tray#readme>
+category:       System
+homepage:       https://github.com/IvanMalison/gtk-sni-tray#readme
+bug-reports:    https://github.com/IvanMalison/gtk-sni-tray/issues
+author:         Ivan Malison
+maintainer:     IvanMalison@gmail.com
+copyright:      2018 Ivan Malison
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/IvanMalison/gtk-sni-tray
+
+library
+  exposed-modules:
+      StatusNotifier.TransparentWindow
+      StatusNotifier.Tray
+  other-modules:
+      Paths_gtk_sni_tray
+  hs-source-dirs:
+      src
+  pkgconfig-depends:
+      gtk+-3.0
+  build-depends:
+      base >=4.7 && <5
+    , bytestring
+    , containers
+    , dbus >=1.0.0 && <2.0.0
+    , directory
+    , enclosed-exceptions >=1.0.0.1
+    , filepath
+    , gi-cairo
+    , gi-cairo-connector
+    , gi-cairo-render
+    , gi-dbusmenugtk3
+    , gi-gdk3
+    , gi-gdkpixbuf >=2.0.16
+    , gi-glib
+    , gi-gtk3
+    , gtk-strut >=0.1.4.0
+    , haskell-gi >=0.21.2
+    , haskell-gi-base >=0.21.1
+    , hslogger
+    , status-notifier-item >=0.3.0.1 && <0.4.0.0
+    , text
+    , transformers
+    , transformers-base >=0.4
+    , unix
+  default-language: Haskell2010
+
+executable gtk-sni-tray-standalone
+  main-is: Main.hs
+  other-modules:
+      Paths_gtk_sni_tray
+  hs-source-dirs:
+      app
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      base
+    , dbus
+    , dbus-hslogger >=0.1.0.1 && <0.2.0.0
+    , gi-gdk3
+    , gi-gtk3
+    , gtk-sni-tray
+    , gtk-strut
+    , hslogger
+    , optparse-applicative
+    , status-notifier-item
+    , text
+    , unix
+  default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                gtk-sni-tray
-version:             0.1.8.1
+version:             0.1.9.0
 github:              "IvanMalison/gtk-sni-tray"
 license:             BSD3
 author:              "Ivan Malison"

--- a/package.yaml
+++ b/package.yaml
@@ -32,7 +32,7 @@ library:
     - gi-gdkpixbuf >= 2.0.16
     - gi-glib
     - gi-gtk3
-    - gtk-strut >= 0.1.2.1
+    - gtk-strut >= 0.1.4.0
     - haskell-gi >= 0.21.2
     - haskell-gi-base >= 0.21.1
     - hslogger
@@ -54,8 +54,8 @@ executables:
       - -rtsopts
       - -with-rtsopts=-N
     dependencies:
-      - base >= 4.7 && < 5
-      - dbus >= 1.0.0 && < 2.0.0
+      - base
+      - dbus
       - dbus-hslogger >= 0.1.0.1 && < 0.2.0.0
       - gi-gdk3
       - gi-gtk3
@@ -63,6 +63,6 @@ executables:
       - gtk-strut
       - hslogger
       - optparse-applicative
-      - status-notifier-item >= 0.3.1.0 && < 0.4.0.0
+      - status-notifier-item
       - text
       - unix


### PR DESCRIPTION
- Bump version so we can make a Hackage release with #34.
- Small CI updates.
- The nix `flake.lock` overrides `gtk-strut` to use taffybar/gtk-strut#10.